### PR TITLE
[Analyze 1922] Add trex connection for cdw svc

### DIFF
--- a/ext/trex/js/cdw_svc.js
+++ b/ext/trex/js/cdw_svc.js
@@ -9,8 +9,8 @@ const BUILT_IN_DIR = "/usr/src/cdw_data/built_in";
 
 export const resolve_cdw_config_duckdb_file_path = () => {
   /*
-		Checks if there is a duckdb file in BUILT_IN_DIR, if there is a file there, use it.
-		Else fallback to using the built in duckdb file in DYNAMICALLY_GENERATED_DIR
+		Checks if there is a duckdb file in DYNAMICALLY_GENERATED_DIR, if there is a file there, use it.
+		Else fallback to using the built in duckdb file in BUILT_IN_DIR
 		*/
   const DUCKDB_FILE_NAME = `${DUCKDB_FILE_DATABASE_CODE}_${DUCKDB_FILE_SCHEMA_NAME}`;
   const DYNAMICALLY_GENERATED_DUCKDB_FILE_PATH = `${DYNAMICALLY_GENERATED_DIR}/${DUCKDB_FILE_NAME}`;

--- a/ext/trex/js/cdw_svc.js
+++ b/ext/trex/js/cdw_svc.js
@@ -1,0 +1,26 @@
+import { existsSync } from "ext:deno_node/_fs/_fs_exists.ts";
+
+export const DUCKDB_FILE_DATABASE_CODE = "cdw_config_svc";
+export const DUCKDB_FILE_SCHEMA_NAME = "validation_schema";
+
+const DYNAMICALLY_GENERATED_DIR = "/usr/src/cdw_data/dynamically_generated";
+const BUILT_IN_DIR = "/usr/src/cdw_data/built_in";
+
+export const resolve_cdw_config_duckdb_file_path = () => {
+  /*
+		Checks if there is a duckdb file in BUILT_IN_DIR, if there is a file there, use it.
+		Else fallback to using the built in duckdb file in DYNAMICALLY_GENERATED_DIR
+		*/
+  const duckdb_file_name = `${DUCKDB_FILE_DATABASE_CODE}_${DUCKDB_FILE_SCHEMA_NAME}`;
+  const default_duckdb_file_path = `${DYNAMICALLY_GENERATED_DIR}/${duckdb_file_name}`;
+
+  if (existsSync(default_duckdb_file_path)) {
+    console.log(
+      `Using dynamically generated duckdb file from ${DYNAMICALLY_GENERATED_DIR}`
+    );
+    return default_duckdb_file_path;
+  } else {
+    console.log(`Using built in duckdb file from ${BUILT_IN_DIR}`);
+    return `${BUILT_IN_DIR}/${duckdb_file_name}`;
+  }
+};

--- a/ext/trex/js/cdw_svc.js
+++ b/ext/trex/js/cdw_svc.js
@@ -1,4 +1,5 @@
 import { existsSync } from "ext:deno_node/_fs/_fs_exists.ts";
+import { statSync } from "ext:deno_node/_fs/_fs_stat.ts";
 
 export const DUCKDB_FILE_DATABASE_CODE = "cdw_config_svc";
 export const DUCKDB_FILE_SCHEMA_NAME = "validation_schema";
@@ -11,16 +12,17 @@ export const resolve_cdw_config_duckdb_file_path = () => {
 		Checks if there is a duckdb file in BUILT_IN_DIR, if there is a file there, use it.
 		Else fallback to using the built in duckdb file in DYNAMICALLY_GENERATED_DIR
 		*/
-  const duckdb_file_name = `${DUCKDB_FILE_DATABASE_CODE}_${DUCKDB_FILE_SCHEMA_NAME}`;
-  const default_duckdb_file_path = `${DYNAMICALLY_GENERATED_DIR}/${duckdb_file_name}`;
+  const DUCKDB_FILE_NAME = `${DUCKDB_FILE_DATABASE_CODE}_${DUCKDB_FILE_SCHEMA_NAME}`;
+  const DYNAMICALLY_GENERATED_DUCKDB_FILE_PATH = `${DYNAMICALLY_GENERATED_DIR}/${DUCKDB_FILE_NAME}`;
+  const BUILT_IN_DUCKDB_FILE_PATH = `${BUILT_IN_DIR}/${DUCKDB_FILE_NAME}`;
 
-  if (existsSync(default_duckdb_file_path)) {
-    console.log(
-      `Using dynamically generated duckdb file from ${DYNAMICALLY_GENERATED_DIR}`
-    );
-    return default_duckdb_file_path;
+  let cdw_duckdb_file_path;
+
+  if (existsSync(DYNAMICALLY_GENERATED_DUCKDB_FILE_PATH)) {
+    cdw_duckdb_file_path = DYNAMICALLY_GENERATED_DUCKDB_FILE_PATH;
   } else {
-    console.log(`Using built in duckdb file from ${BUILT_IN_DIR}`);
-    return `${BUILT_IN_DIR}/${duckdb_file_name}`;
+    cdw_duckdb_file_path = BUILT_IN_DUCKDB_FILE_PATH;
   }
+  console.log(`Using cdw_svc duckdb file from ${cdw_duckdb_file_path}`);
+  return [cdw_duckdb_file_path, statSync(cdw_duckdb_file_path).mtime];
 };

--- a/ext/trex/js/trex_lib.js
+++ b/ext/trex/js/trex_lib.js
@@ -41,6 +41,11 @@ export async function prompt(xprompt, model = null) {
 
 export class DatabaseManager {
 	static #dbm;
+
+	// Information regarding attached cdw-svc duckdb file
+	#attached_cdw_svc_file_path = null;
+	#attached_cdw_svc_file_mtime = null;
+
 	#contructor() {}
 
 	static getDatabaseManager() {
@@ -83,16 +88,35 @@ export class DatabaseManager {
         );
 			}
 
-	add_cdw_config_duckdb_connection() {
-		/*
+  add_cdw_config_duckdb_connection() {
+    /*
 		Checks if there is a duckdb file in /usr/src/cdw_data/dynamically_generated, if there is a file there, use it.
 		Else fallback to using the built in duckdb file in /usr/src/cdw_data/built_in
 		*/
-		const duckdb_file_path = resolve_cdw_config_duckdb_file_path()
-		op_execute_query("memory",
-        `ATTACH IF NOT EXISTS '${duckdb_file_path}' AS ${DUCKDB_FILE_SCHEMA_NAME} (READ_ONLY)`, []
-        );
+    const [duckdb_file_path, file_mtime] =
+      resolve_cdw_config_duckdb_file_path();
+
+    if (
+      this.#attached_cdw_svc_file_path === null || // File not attached yet
+      this.#attached_cdw_svc_file_mtime === null || // File not attached yet
+      duckdb_file_path !== this.#attached_cdw_svc_file_path || // There is a new dynamically created cdw-svc duckdb file
+      file_mtime > this.#attached_cdw_svc_file_mtime // There is a new dynamically created cdw-svc duckdb file
+    ) {
+      op_execute_query(
+        "memory",
+        `DETACH DATABASE IF EXISTS ${DUCKDB_FILE_SCHEMA_NAME}`,
+        []
+      );
+      op_execute_query(
+        "memory",
+        `ATTACH IF NOT EXISTS '${duckdb_file_path}' AS ${DUCKDB_FILE_SCHEMA_NAME} (READ_ONLY)`,
+        []
+      );
     }
+    this.#attached_cdw_svc_file_path = duckdb_file_path;
+    this.#attached_cdw_svc_file_mtime = file_mtime;
+  }
+
 
 	#updatePublications() {
 		for(const c of this.getCredentials()) {

--- a/ext/trex/js/trex_lib.js
+++ b/ext/trex/js/trex_lib.js
@@ -1,6 +1,7 @@
 import { core } from "ext:core/mod.js";
 import { TrexConnection } from './pgconnection.js';
 import { HanaConnection } from './hdbconnection.js';
+import { resolve_cdw_config_duckdb_file_path, DUCKDB_FILE_DATABASE_CODE, DUCKDB_FILE_SCHEMA_NAME } from "./cdw_svc.js"
 
 //import * as hdb from './hdb.js';
 //import * as p from './postgres.js';
@@ -79,6 +80,17 @@ export class DatabaseManager {
 		op_execute_query("memory","LOAD bigquery",[]);
 		op_execute_query("memory",
         `ATTACH IF NOT EXISTS 'project=${credentials.project} dataset=${credentials.dataset}' AS ${name} (TYPE bigquery, READ_ONLY)`, []
+        );
+			}
+
+	add_cdw_config_duckdb_connection() {
+		/*
+		Checks if there is a duckdb file in /usr/src/cdw_data/dynamically_generated, if there is a file there, use it.
+		Else fallback to using the built in duckdb file in /usr/src/cdw_data/built_in
+		*/
+		const duckdb_file_path = resolve_cdw_config_duckdb_file_path()
+		op_execute_query("memory",
+        `ATTACH IF NOT EXISTS '${duckdb_file_path}' AS ${DUCKDB_FILE_SCHEMA_NAME} (READ_ONLY)`, []
         );
     }
 
@@ -176,6 +188,13 @@ export class TrexDB {
 	#database;
 	constructor(database) {
 		const dbm = DatabaseManager.getDatabaseManager();
+
+		if (database === DUCKDB_FILE_DATABASE_CODE) {
+      this.#database = DUCKDB_FILE_DATABASE_CODE;
+			dbm.add_cdw_config_duckdb_connection()
+      return;
+    }
+
 		if(database in dbm.getPublications()) {
 			this.#database = database;
 		} else {

--- a/ext/trex/lib.rs
+++ b/ext/trex/lib.rs
@@ -645,6 +645,7 @@ deno_core::extension!(
     esm = [
         "js/trex_lib.js",
         "js/pgconnection.js",
-        "js/hdbconnection.js"
+        "js/hdbconnection.js",
+        "js/cdw_svc.js"
     ]
 );


### PR DESCRIPTION
- resolves: https://github.com/data2evidence/internal/issues/1922

1. Add logic in `DatabaseManager` to attach and detach cdw-svc duckdb files based on file path and mtime.