### PR TITLE
[Analyze-2063] Expose getFirstPublication to trex functions

### DIFF
--- a/ext/trex/js/trex_lib.js
+++ b/ext/trex/js/trex_lib.js
@@ -199,6 +199,10 @@ export class UserDatabaseManager {
 	getDatabaseCredentials() {
 		return this.#dbm.getCredentials();
 	}
+	
+	getFirstPublication(db_id) {
+		return this.#dbm.getFirstPublication(db_id);
+	}
 
 
 	getConnection(db_id, schema, vocab_schema, translationMap) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@data2evidence/cli": "https://github.com/data2evidence/d2e/releases/download/latest/data2evidence-cli.tgz",
+    "@data2evidence/cli": "https://github.com/OHDSI/d2e/releases/download/latest/data2evidence-cli.tgz",
     "nodemon": "^3.1.4"
   }
 }


### PR DESCRIPTION
- resolves: https://github.com/data2evidence/internal/issues/2063

1. Expose getFirstPublication to trex functions
2. Update d2e cli repo to `OHDSI/d2e`